### PR TITLE
優先順位の追加

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -51,6 +51,6 @@ class TasksController < ApplicationController
   end
   
   def task_params
-    params.require(:task).permit(:title, :content)
+    params.require(:task).permit(:title, :content, :deadline, :status, :priority)
   end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,5 +1,5 @@
 module TasksHelper
-  def ja_select(columns, column)
+  def show_japanese_choices(columns, column)
     columns.keys.map { |k| [I18n.t("enums.task.#{column}.#{k}"), k] }
   end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,2 +1,5 @@
 module TasksHelper
+  def ja_select(columns, column)
+    columns.keys.map {|k| [I18n.t("enums.task.#{column}.#{k}"), k]}
+  end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,5 +1,5 @@
 module TasksHelper
   def ja_select(columns, column)
-    columns.keys.map {|k| [I18n.t("enums.task.#{column}.#{k}"), k]}
+    columns.keys.map { |k| [I18n.t("enums.task.#{column}.#{k}"), k] }
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,6 @@
 class Task < ApplicationRecord
   enum status: { default: 0, untouched: 1, in_progress: 2, done: 3 }
-  enum priority: { high: 0, middle: 1, low: 2, undefine: 3 }
+  enum priority: { high: 0, middle: 1, low: 2 }
 
   validates :title, presence: true
   validates :content, length: { maximum: 280 }

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,6 @@
 class Task < ApplicationRecord
+  enum status: { default: 0, untouched: 1, in_progress: 2, done: 3 }
+  enum priority: { high: 0, middle: 1, low: 2, undefine: 3 }
   validates :title, presence: true
   validates :content, length: { maximum: 280 }
 end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -11,6 +11,6 @@
   <%= form.label :content, '内容' %>
   <%= form.text_field :content %>
   <%= form.label :priority, '優先順位' %>
-  <%= form.select :priority, { '--': 'undefine', '高': 'high', '中': 'middle', '低': 'low'}%>
+  <%= form.select :priority, Task.priorities.keys.map {|k| [I18n.t("enums.task.priority.#{k}"), k]}%>
   <%= form.submit "完了" %>
 <% end %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -13,8 +13,8 @@
   <%= form.label :deadline, '終了期限' %>
   <%= form.datetime_field :deadline, {} %>
   <%= form.label :status, 'ステータス' %>
-  <%= form.select :status, Task.statuses.keys.map {|k| [I18n.t("enums.task.status.#{k}"), k]} %>
+  <%= form.select :status, ja_select(Task.statuses, 'status') %>
   <%= form.label :priority, '優先順位' %>
-  <%= form.select :priority, Task.priorities.keys.map {|k| [I18n.t("enums.task.priority.#{k}"), k]}%>
+  <%= form.select :priority, ja_select(Task.priorities, 'priority')%>
   <%= form.submit "完了" %>
 <% end %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -10,5 +10,7 @@
   <%= form.text_field :title %>
   <%= form.label :content, '内容' %>
   <%= form.text_field :content %>
+  <%= form.label :priority, '優先順位' %>
+  <%= form.select :priority, { '--': 'undefine', '高': 'high', '中': 'middle', '低': 'low'}%>
   <%= form.submit "完了" %>
 <% end %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -13,8 +13,8 @@
   <%= form.label :deadline, '終了期限' %>
   <%= form.datetime_field :deadline, {} %>
   <%= form.label :status, 'ステータス' %>
-  <%= form.select :status, ja_select(Task.statuses, 'status') %>
+  <%= form.select :status, show_japanese_choices(Task.statuses, 'status') %>
   <%= form.label :priority, '優先順位' %>
-  <%= form.select :priority, ja_select(Task.priorities, 'priority')%>
+  <%= form.select :priority, show_japanese_choices(Task.priorities, 'priority')%>
   <%= form.submit "完了" %>
 <% end %>

--- a/app/views/tasks/_order_form.html.erb
+++ b/app/views/tasks/_order_form.html.erb
@@ -4,7 +4,9 @@
     ['作成日時が早い', 'created_at,asc'],
     ['作成日時が遅い', 'created_at,desc'],
     ['終了期限が近い', 'deadline,asc'],
-    ['終了期限が遅い', 'deadline,desc']
+    ['終了期限が遅い', 'deadline,desc'],
+    ['優先度が高い', 'priority,asc'],
+    ['優先度が低い', 'priority,desc']
   ]%>
   <%= form.submit '並び替え' %>
 <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,5 +1,18 @@
 <h1>TODOリスト</h1>
-<% @tasks.each do |task| %>
-  <p class="task_id"><%= task.id %></p>
-  <p class="task_title"><%= task.title%></p>
-<% end %>
+<table>
+  <tr>
+    <th>ID</th>
+    <th><%= sort_order 'created_at', 'タイトル' %></th>
+    <th><%= sort_order 'priority', '優先順位' %></th>
+  </tr>
+  <% @tasks.each do |task| %>
+    <tr>
+      <td class='task_id'><%= task.id %></td>
+      <td class='task_title'>
+        <%= link_to task.title, task_path(task.id) %>
+      </td>
+      <td class='task_priority'><%= I18n.t("enums.task.priority.#{task.priority}") %></td>
+    </tr>
+  <% end %>
+</table>
+<%= link_to '作成', new_task_path %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -16,8 +16,8 @@
         <%= link_to task.title, task_path(task.id) %>
       </td>
       <td class="task_deadline"><%= l task.deadline, format: :short %></td>
-      <td class='task_priority'><%= I18n.t("enums.task.priority.#{task.priority}") %></td>
       <td class="task_status"><%= I18n.t("enums.task.status.#{task.status}") %></td>
+      <td class='task_priority'><%= I18n.t("enums.task.priority.#{task.priority}") %></td>
     </tr>
   <% end %>
 </table>

--- a/config/locales/views/tasks/ja.yml
+++ b/config/locales/views/tasks/ja.yml
@@ -17,7 +17,6 @@ ja:
         in_progress: 着手中
         done: 完了
       priority:
-        undefine: --
         high: 高
         middle: 中
         low: 低

--- a/config/locales/views/tasks/ja.yml
+++ b/config/locales/views/tasks/ja.yml
@@ -6,6 +6,16 @@ ja:
       task:
         title: タイトル
         content: 内容
+        deadline: 終了期限
+        status: ステータス
+        priority: 優先順位
+  enums:
+    task:
+      priority:
+        undefine: --
+        high: 高
+        middle: 中
+        low: 低
   notice:
     new: タスクを作成しました
     update: タスクを更新しました

--- a/db/migrate/20210301025328_add_priority_to_tasks.rb
+++ b/db/migrate/20210301025328_add_priority_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddPriorityToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :priority, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_02_132546) do
+ActiveRecord::Schema.define(version: 2021_03_01_025328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,9 @@ ActiveRecord::Schema.define(version: 2021_02_02_132546) do
     t.boolean "is_done", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deadline"
+    t.integer "status", null: false
+    t.integer "priority", null: false
   end
 
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -2,5 +2,7 @@ FactoryBot.define do
   factory :task do
     title { "title" }
     content { 'content' }
+    status { 'untouched' }
+    priority { 'undefine' }
   end
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -3,11 +3,15 @@ FactoryBot.define do
     "#{i} Feb 2021 11:38:00 JST +09:00"
   end
 
+  sequence :task_priority do |i|
+    (i - 1) % 3
+  end
+
   factory :task do
     title { "title" }
     content { 'content' }
     deadline { generate :task_deadline }
     status { 'untouched' }
-    priority { 'undefine' }
+    priority { generate :task_priority }
   end
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Tasks', type: :system do
-  describe "ソート" do
+  describe 'ソート' do
     let(:tasks) { create_list(:task, 3) }
 
     before do 

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe 'Tasks', type: :system do
       tasks_expect = tasks.reverse
       visit tasks_path
       task_list = all('.task_id')
-      expect(task_list[0]).to have_content tasks_expect[0].id
-      expect(task_list[1]).to have_content tasks_expect[1].id
-      expect(task_list[2]).to have_content tasks_expect[2].id
+      (0..2).each do |i|
+        expect(task_list[i]).to have_content tasks_expect[i].id
+      end
     end
 
     it 'deadlineの昇順になること' do
@@ -22,9 +22,9 @@ RSpec.describe 'Tasks', type: :system do
       select '終了期限が近い', from: '並び替え'
       click_on '並び替え'
       task_list = all('.task_deadline')
-      expect(task_list[0]).to have_content I18n.l(tasks[0].deadline, format: :short)
-      expect(task_list[1]).to have_content I18n.l(tasks[1].deadline, format: :short)
-      expect(task_list[2]).to have_content I18n.l(tasks[2].deadline, format: :short)
+      (0..2).each do |i|
+        expect(task_list[i]).to have_content I18n.l(tasks[i].deadline, format: :short)
+      end
     end
 
     it 'deadlineの降順になること' do
@@ -33,9 +33,9 @@ RSpec.describe 'Tasks', type: :system do
       select '終了期限が遅い', from: '並び替え'
       click_on '並び替え'
       task_list = all('.task_deadline')
-      expect(task_list[0]).to have_content I18n.l(tasks_expect[0].deadline, format: :short)
-      expect(task_list[1]).to have_content I18n.l(tasks_expect[1].deadline, format: :short)
-      expect(task_list[2]).to have_content I18n.l(tasks_expect[2].deadline, format: :short)
+      (0..2).each do |i|
+        expect(task_list[i]).to have_content I18n.l(tasks_expect[i].deadline, format: :short)
+      end
     end
     
     it '優先度が高い順にソートされること' do
@@ -43,9 +43,9 @@ RSpec.describe 'Tasks', type: :system do
       select '優先度が高い', from: '並び替え'
       click_on '並び替え'
       task_list = all('.task_priority')
-      expect(task_list[0]).to have_content I18n.t("enums.task.priority.#{tasks[0].priority}")
-      expect(task_list[1]).to have_content I18n.t("enums.task.priority.#{tasks[1].priority}")
-      expect(task_list[2]).to have_content I18n.t("enums.task.priority.#{tasks[2].priority}")
+      (0..2).each do |i|
+        expect(task_list[i]).to have_content I18n.t("enums.task.priority.#{tasks[i].priority}")
+      end
     end
 
     it '優先度が低い順にソートされること' do

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -2,17 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'Tasks', type: :system do
   describe "ソート" do
-    let(:task_1) { create(:task, priority: 'high') }
-    let(:task_2) { create(:task, priority: 'low') }
-    let(:task_3) { create(:task, priority: 'middle') }
-    let(:task_4) { create(:task, priority: 'undefine') }
+    let(:tasks) { create_list(:task, 3) }
 
     before do 
-      task_1
-      task_2
-      task_3
-      task_4
-      task_5
+      tasks
     end
     
     it 'created_atの降順になること' do
@@ -45,27 +38,25 @@ RSpec.describe 'Tasks', type: :system do
       expect(task_list[2]).to have_content I18n.l(tasks_expect[2].deadline, format: :short)
     end
     
-    it '優先順位が高い順にソートされること' do
+    it '優先度が高い順にソートされること' do
       visit tasks_path
-      # 優先順位が高い順にソート
-      click_on '優先順位'
+      select '優先度が高い', from: '並び替え'
+      click_on '並び替え'
       task_list = all('.task_priority')
-      expect(task_list[0]).to have_content I18n.t("enums.task.priority.#{task_1.priority}")
-      expect(task_list[1]).to have_content I18n.t("enums.task.priority.#{task_3.priority}")
-      expect(task_list[2]).to have_content I18n.t("enums.task.priority.#{task_2.priority}")
-      expect(task_list[3]).to have_content I18n.t("enums.task.priority.#{task_4.priority}")
+      expect(task_list[0]).to have_content I18n.t("enums.task.priority.#{tasks[0].priority}")
+      expect(task_list[1]).to have_content I18n.t("enums.task.priority.#{tasks[1].priority}")
+      expect(task_list[2]).to have_content I18n.t("enums.task.priority.#{tasks[2].priority}")
     end
 
-    it '優先順位が低い順にソートされること' do
+    it '優先度が低い順にソートされること' do
       visit tasks_path
-      # 優先順位が低い順にソート
-      click_on '優先順位'
-      click_on '優先順位'
+      select '優先度が低い', from: '並び替え'
+      click_on '並び替え'
       task_list = all('.task_priority')
-      expect(task_list[0]).to have_content I18n.t("enums.task.priority.#{task_4.priority}")
-      expect(task_list[1]).to have_content I18n.t("enums.task.priority.#{task_2.priority}")
-      expect(task_list[2]).to have_content I18n.t("enums.task.priority.#{task_3.priority}")
-      expect(task_list[3]).to have_content I18n.t("enums.task.priority.#{task_1.priority}")
+      expect(task_list[0]).to have_content I18n.t("enums.task.priority.#{tasks[2].priority}")
+      expect(task_list[1]).to have_content I18n.t("enums.task.priority.#{tasks[1].priority}")
+      expect(task_list[2]).to have_content I18n.t("enums.task.priority.#{tasks[0].priority}")
+    end
   end 
     
   describe '検索機能' do
@@ -77,28 +68,31 @@ RSpec.describe 'Tasks', type: :system do
     before { visit tasks_path }
  
     context 'タイトルとステータスを入力する場合' do
+      before do 
+        task_1
+        task_2
+        task_3
+        task_4
+        task_5
+      end
       context '正常系' do
         it '--のタスクが検索されること' do
-          fill_in 'タイトル', with: 'sample'
           select '--', from: 'ステータス'
           click_on 'search'
           expect(page).to have_content 'sample1'
         end
         it '未着手のタスクが検索されること' do
-          fill_in 'タイトル', with: 'sample'
           select '未着手', from: 'ステータス'
           click_on 'search'
           expect(page).to have_content 'sample2'
           expect(page).to have_content 'sample3'
         end
         it '着手中のタスクが検索されること' do
-          fill_in 'タイトル', with: 'sample'
           select '着手中', from: 'ステータス'
           click_on 'search'
           expect(page).to have_content 'sample4'
         end
         it '完了のタスクが検索されること' do
-          fill_in 'タイトル', with: 'sample'
           select '完了', from: 'ステータス'
           click_on 'search'
           expect(page).to have_content 'sample5'
@@ -108,13 +102,7 @@ RSpec.describe 'Tasks', type: :system do
       context '異常系' do
         it 'タスクが見つからないこと' do
           fill_in 'タイトル', with: ''
-          select '--', from: 'ステータス'
           click_on 'search'
-          expect(page).to have_content 'sample1'
-          expect(page).to have_content 'sample2'
-          expect(page).to have_content 'sample3'
-          expect(page).to have_content 'sample4'
-          expect(page).to have_content 'sample5'
           expect(page).to have_content 'タスクを見つけられませんでした'
         end
       end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe 'Tasks', type: :system do
         tasks_expect = tasks.reverse
         visit tasks_path
         task_list = all('.task_id')
-        (0..2).each do |i|
-          expect(task_list[i]).to have_content tasks_expect[i].id
+        task_list.each_with_index do |task, i|
+          expect(task).to have_content tasks_expect[i].id
         end
       end
     end
@@ -25,8 +25,8 @@ RSpec.describe 'Tasks', type: :system do
         select '終了期限が近い', from: '並び替え'
         click_on '並び替え'
         task_list = all('.task_deadline')
-        (0..2).each do |i|
-          expect(task_list[i]).to have_content I18n.l(tasks[i].deadline, format: :short)
+        task_list.each_with_index do |task, i|
+          expect(task).to have_content I18n.l(tasks[i].deadline, format: :short)
         end
       end
 
@@ -36,8 +36,8 @@ RSpec.describe 'Tasks', type: :system do
         select '終了期限が遅い', from: '並び替え'
         click_on '並び替え'
         task_list = all('.task_deadline')
-        (0..2).each do |i|
-          expect(task_list[i]).to have_content I18n.l(tasks_expect[i].deadline, format: :short)
+        task_list.each_with_index do |task, i|
+          expect(task).to have_content I18n.l(tasks_expect[i].deadline, format: :short)
         end
       end
     end
@@ -48,19 +48,20 @@ RSpec.describe 'Tasks', type: :system do
         select '優先度が高い', from: '並び替え'
         click_on '並び替え'
         task_list = all('.task_priority')
-        (0..2).each do |i|
-          expect(task_list[i]).to have_content I18n.t("enums.task.priority.#{tasks[i].priority}")
+        task_list.each_with_index do |task, i|
+          expect(task).to have_content I18n.t("enums.task.priority.#{tasks[i].priority}")
         end
       end
 
       it '優先度が低い順にソートされること' do
+        tasks_expect = tasks.reverse
         visit tasks_path
         select '優先度が低い', from: '並び替え'
         click_on '並び替え'
         task_list = all('.task_priority')
-        expect(task_list[0]).to have_content I18n.t("enums.task.priority.#{tasks[2].priority}")
-        expect(task_list[1]).to have_content I18n.t("enums.task.priority.#{tasks[1].priority}")
-        expect(task_list[2]).to have_content I18n.t("enums.task.priority.#{tasks[0].priority}")
+        task_list.each_with_index do |task, i|
+          expect(task).to have_content I18n.t("enums.task.priority.#{tasks_expect[i].priority}")
+        end
       end
     end
   end 

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -17,4 +17,40 @@ RSpec.describe 'Tasks', type: :system do
       expect(task_list[2]).to have_content tasks_expect[2].id
     end
   end
+  describe "ソート" do
+    let(:task_1) { create(:task, priority: 'high') }
+    let(:task_2) { create(:task, priority: 'low') }
+    let(:task_3) { create(:task, priority: 'middle') }
+    let(:task_4) { create(:task, priority: 'undefine') }
+
+    before do 
+      task_1
+      task_2
+      task_3
+      task_4
+    end
+    
+    it '優先順位が高い順にソートされること' do
+      visit tasks_path
+      # 優先順位が高い順にソート
+      click_on '優先順位'
+      task_list = all('.task_priority')
+      expect(task_list[0]).to have_content I18n.t("enums.task.priority.#{task_1.priority}")
+      expect(task_list[1]).to have_content I18n.t("enums.task.priority.#{task_3.priority}")
+      expect(task_list[2]).to have_content I18n.t("enums.task.priority.#{task_2.priority}")
+      expect(task_list[3]).to have_content I18n.t("enums.task.priority.#{task_4.priority}")
+    end
+
+    it '優先順位が低い順にソートされること' do
+      visit tasks_path
+      # 優先順位が低い順にソート
+      click_on '優先順位'
+      click_on '優先順位'
+      task_list = all('.task_priority')
+      expect(task_list[0]).to have_content I18n.t("enums.task.priority.#{task_4.priority}")
+      expect(task_list[1]).to have_content I18n.t("enums.task.priority.#{task_2.priority}")
+      expect(task_list[2]).to have_content I18n.t("enums.task.priority.#{task_3.priority}")
+      expect(task_list[3]).to have_content I18n.t("enums.task.priority.#{task_1.priority}")
+    end
+  end
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -8,54 +8,60 @@ RSpec.describe 'Tasks', type: :system do
       tasks
     end
     
-    it 'created_atの降順になること' do
-      tasks_expect = tasks.reverse
-      visit tasks_path
-      task_list = all('.task_id')
-      (0..2).each do |i|
-        expect(task_list[i]).to have_content tasks_expect[i].id
+    context 'created_at' do
+      it '降順になること' do
+        tasks_expect = tasks.reverse
+        visit tasks_path
+        task_list = all('.task_id')
+        (0..2).each do |i|
+          expect(task_list[i]).to have_content tasks_expect[i].id
+        end
       end
     end
 
-    it 'deadlineの昇順になること' do
-      visit tasks_path
-      select '終了期限が近い', from: '並び替え'
-      click_on '並び替え'
-      task_list = all('.task_deadline')
-      (0..2).each do |i|
-        expect(task_list[i]).to have_content I18n.l(tasks[i].deadline, format: :short)
+    context 'deadline' do
+      it '昇順になること' do
+        visit tasks_path
+        select '終了期限が近い', from: '並び替え'
+        click_on '並び替え'
+        task_list = all('.task_deadline')
+        (0..2).each do |i|
+          expect(task_list[i]).to have_content I18n.l(tasks[i].deadline, format: :short)
+        end
       end
-    end
 
-    it 'deadlineの降順になること' do
-      tasks_expect = tasks.reverse
-      visit tasks_path
-      select '終了期限が遅い', from: '並び替え'
-      click_on '並び替え'
-      task_list = all('.task_deadline')
-      (0..2).each do |i|
-        expect(task_list[i]).to have_content I18n.l(tasks_expect[i].deadline, format: :short)
+      it '降順になること' do
+        tasks_expect = tasks.reverse
+        visit tasks_path
+        select '終了期限が遅い', from: '並び替え'
+        click_on '並び替え'
+        task_list = all('.task_deadline')
+        (0..2).each do |i|
+          expect(task_list[i]).to have_content I18n.l(tasks_expect[i].deadline, format: :short)
+        end
       end
     end
     
-    it '優先度が高い順にソートされること' do
-      visit tasks_path
-      select '優先度が高い', from: '並び替え'
-      click_on '並び替え'
-      task_list = all('.task_priority')
-      (0..2).each do |i|
-        expect(task_list[i]).to have_content I18n.t("enums.task.priority.#{tasks[i].priority}")
+    context 'priority' do
+      it '優先度が高い順にソートされること' do
+        visit tasks_path
+        select '優先度が高い', from: '並び替え'
+        click_on '並び替え'
+        task_list = all('.task_priority')
+        (0..2).each do |i|
+          expect(task_list[i]).to have_content I18n.t("enums.task.priority.#{tasks[i].priority}")
+        end
       end
-    end
 
-    it '優先度が低い順にソートされること' do
-      visit tasks_path
-      select '優先度が低い', from: '並び替え'
-      click_on '並び替え'
-      task_list = all('.task_priority')
-      expect(task_list[0]).to have_content I18n.t("enums.task.priority.#{tasks[2].priority}")
-      expect(task_list[1]).to have_content I18n.t("enums.task.priority.#{tasks[1].priority}")
-      expect(task_list[2]).to have_content I18n.t("enums.task.priority.#{tasks[0].priority}")
+      it '優先度が低い順にソートされること' do
+        visit tasks_path
+        select '優先度が低い', from: '並び替え'
+        click_on '並び替え'
+        task_list = all('.task_priority')
+        expect(task_list[0]).to have_content I18n.t("enums.task.priority.#{tasks[2].priority}")
+        expect(task_list[1]).to have_content I18n.t("enums.task.priority.#{tasks[1].priority}")
+        expect(task_list[2]).to have_content I18n.t("enums.task.priority.#{tasks[0].priority}")
+      end
     end
   end 
     


### PR DESCRIPTION
## 概要
優先順位の追加

## 要件・仕様
ステップ18: 優先順位を設定しよう（※類似した実装経験のある人は省略可）
https://github.com/buysell-technologies/el-training/blob/master/docs/el-training.md

## 動作確認
- 優先度が高いでソートした場合
<img width="484" alt="スクリーンショット 2021-03-10 10 13 47" src="https://user-images.githubusercontent.com/78336288/110560540-86fa8600-8189-11eb-8c04-d72ef7982673.png">

- 優先度が低いでソートした場合
<img width="463" alt="スクリーンショット 2021-03-10 10 14 26" src="https://user-images.githubusercontent.com/78336288/110560546-895ce000-8189-11eb-9e7d-07bf22451a92.png">

