### PR TITLE
ステータス、期限の修正

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,5 @@
 class Task < ApplicationRecord
-  enum status: { default: 0, untouched: 1, in_progress: 2, done: 3 }
+  enum status: { untouched: 0, in_progress: 1, done: 2 }
   enum priority: { high: 0, middle: 1, low: 2 }
 
   validates :title, presence: true

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,7 +2,7 @@ ja:
   time:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
-      short: "%m/%d %H:%M"
+      short: "%m/%d"
   views:
     pagination:
       first: '<<'

--- a/config/locales/views/tasks/ja.yml
+++ b/config/locales/views/tasks/ja.yml
@@ -12,7 +12,6 @@ ja:
   enums:
     task:
       status:
-        default: --
         untouched: 未着手
         in_progress: 着手中
         done: 完了


### PR DESCRIPTION
## 概要
- ステータスのdefaultの削除
- 終了期限の表示変更

## 要件・仕様
- ステータスのdefaultの削除
   - defaultはuntouchedと代用可能なため削除
- 終了期限の表示変更
   - 表示する際長すぎたのでみやすいように短くした 