### PR TITLE
タスク画面のデザイン修正

### DIFF
--- a/app/assets/javascripts/tasks.coffee
+++ b/app/assets/javascripts/tasks.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/tasks.js
+++ b/app/assets/javascripts/tasks.js
@@ -4,15 +4,17 @@ function showDoneButton(idName) {
   document.getElementById(idName).style.display = 'block';
 }
 
+// 内容が変更されると完了ボタンが表示
+document.getElementById('task_content').onchange = function() {
+  showDoneButton('tasks-form-button')
+}
+
 // タイトルが変更されると完了ボタンが表示
 document.getElementById('task_title').onchange = function() {
   showDoneButton('tasks-form-button')
 }
 
-// 内容が変更されると完了ボタンが表示
-document.getElementById('task_content').onchange = function() {
-  showDoneButton('tasks-form-button')
-}
+
 
 // 期限が変更されると完了ボタンが表示
 document.getElementById('task_deadline').onchange = function() {

--- a/app/assets/javascripts/tasks.js
+++ b/app/assets/javascripts/tasks.js
@@ -1,0 +1,31 @@
+// 完了ボタンを表示 start
+// 完了ボタンが表示する
+function showDoneButton(idName) {
+  document.getElementById(idName).style.display = 'block';
+}
+
+// タイトルが変更されると完了ボタンが表示
+document.getElementById('task_title').onchange = function() {
+  showDoneButton('tasks-form-button')
+}
+
+// 内容が変更されると完了ボタンが表示
+document.getElementById('task_content').onchange = function() {
+  showDoneButton('tasks-form-button')
+}
+
+// 期限が変更されると完了ボタンが表示
+document.getElementById('task_deadline').onchange = function() {
+  showDoneButton('tasks-form-button')
+}
+
+// 優先順位が変更されると完了ボタンが表示
+document.getElementById('task_priority').onchange = function() {
+  showDoneButton('tasks-form-button')
+}
+
+// ステータスが変更されると完了ボタンが表示
+document.getElementById('task_status').onchange = function() {
+  showDoneButton('tasks-form-button')
+}
+// 完了ボタンを表示 end

--- a/app/assets/stylesheets/_initialisation.scss
+++ b/app/assets/stylesheets/_initialisation.scss
@@ -1,5 +1,8 @@
+@import 'variable';
+
 *{
   margin: 0;
+  font-family: "MS Pゴシック" ;
 }
 
 h1, h2, h3, h4{
@@ -16,6 +19,11 @@ a{
   text-decoration: none;
 }
 
+p{
+  margin-block-start: 0;
+  margin-block-end: 0;
+}
+
 ul, li{
   margin-block-start: 0;
   margin-block-end: 0;
@@ -23,3 +31,19 @@ ul, li{
   list-style: none;
 }
 
+input, select, textarea{
+  font-size: $base-font-size;
+  border: none;
+  appearance: none;
+  white-space: normal;
+  word-break: break-all;
+  // 矢印の消去
+  &::-ms-expand {
+    display: none;
+  }
+
+  // カレンダーのアイコンの消去
+  &[type="date"]::-webkit-calendar-picker-indicator {
+    background: none;
+  }
+}

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -216,56 +216,6 @@
     }
   }
 
-  // form
-
-  &-form{
-    padding: 55px;
-    display: flex;
-    flex-direction: column;
-    border-radius: 90px 90px 0 0;
-    background-color: $base-color-white;
-    position: absolute;
-    bottom: 0;
-    z-index: 2;
-
-    &__title{
-      width: calc(100vw - 180px);
-    }
-
-    &__deadline{
-      width: 100px;
-      overflow: hidden;
-    }
-
-    &__top{
-      margin-bottom: $space;
-    }
-
-    label{
-      display: none;
-    }
-
-    input{
-      padding: 20px 35px;
-      background-color: $form-background-color;
-      font-size: $form-font-size;
-      border-radius: 60px;
-    }
-
-    select{
-      padding: 30px 35px;
-      background-color: $form-background-color;
-      font-size: $form-font-size;
-      border-radius: 60px;
-    }
-
-    .field_with_errors input, .field_with_errors textarea, .field_with_errors select{
-      color: $admin-color;
-      border: solid $admin-color;
-      background-color: #FFEFEF;
-    }
-  }
-
   // search_form
 
   &-search{

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -128,21 +128,141 @@
     background-color: $base-color;
   }
 
+  // タスク画面
+  &-show{
+    // タスク詳細のアイコン
+    &__icon{
+      &--title{
+        font-size: 57px !important;
+      }
+
+      &--deadline{
+        font-size: 57px !important;
+      }
+
+      &--content{
+        margin-top: 10px;
+        font-size: 53px !important;
+      }
+
+      &--status{
+        font-size: 53px !important;
+      }
+
+      &--priority{
+        font-size: 48px !important;
+      }
+
+      &--destroy{
+        font-size: 66px !important;
+      }
+    }
+
+    &__title{
+      width: calc(100vw - 215px);
+      overflow-wrap: break-word;
+      white-space: pre-line;
+      word-break: break-all;
+    }
+
+    &__content{
+      width: calc(100vw - 215px);
+      font-size: 33px;
+      overflow-wrap: break-word;
+    }
+
+    &__destroy{
+      margin-top: 138px;
+    }
+
+    // タスク詳細全体のアイコン
+    i{
+      color: $base-color;
+      margin-right: $space;
+    }
+
+    li{
+      display: flex;
+      flex-direction: row;
+      margin-bottom: $space;
+    }
+
+  }
+
+  // 戻るのアイコン、文言
+  &-back{
+    display: flex;
+    flex-direction: row;
+    color: $base-color;
+    position: absolute;
+    &__icon{
+      font-size: 65px !important;
+      margin-right: 20px;
+    }
+  }
+
+  &-select{
+    display: flex;
+    flex-direction: row;
+
+    // selectタグの矢印
+    &__bar{
+      width: 20px;
+      height: 20px;
+      margin: 23px 0 0 30px;
+      border-bottom: $base-color-black 5px solid;
+      border-right: $base-color-black 5px solid;
+      transform:rotate(45deg)translateY(-30%);
+    }
+  }
+
   // form
 
   &-form{
-    width: 727px;
-    margin: 30px calc(60vw - 727px / 2);
-    padding-bottom: 30px;
+    padding: 55px;
+    display: flex;
+    flex-direction: column;
+    border-radius: 90px 90px 0 0;
     background-color: $base-color-white;
-    border-radius: 5px;
-    overflow: hidden;
-  
+    position: absolute;
+    bottom: 0;
+    z-index: 2;
+
     &__title{
-      padding: 10px 0 10px 30px;
-      background-color: #333;
-      border-radius: 5px 5px 0 0;
-      color: $base-color-white;
+      width: calc(100vw - 180px);
+    }
+
+    &__deadline{
+      width: 100px;
+      overflow: hidden;
+    }
+
+    &__top{
+      margin-bottom: $space;
+    }
+
+    label{
+      display: none;
+    }
+
+    input{
+      padding: 20px 35px;
+      background-color: $form-background-color;
+      font-size: $form-font-size;
+      border-radius: 60px;
+    }
+
+    select{
+      padding: 30px 35px;
+      background-color: $form-background-color;
+      font-size: $form-font-size;
+      border-radius: 60px;
+    }
+
+    .field_with_errors input, .field_with_errors textarea, .field_with_errors select{
+      color: $admin-color;
+      border: solid $admin-color;
+      background-color: #FFEFEF;
     }
   }
 
@@ -188,42 +308,7 @@
       border: none;
     }
   }
-
-  // show
-
-  &-show{
-    margin: 30px calc(60vw - 727px / 2);
-    width: 727px;
-    background-color: $base-color-white;
-    border-radius: 5px;
-    overflow: hidden;
-    padding-bottom: 30px;
-  
-    &__title{
-      padding: 10px 0 10px 30px;
-      background-color: #333;
-      color: $base-color-white;
-    }
-  
-    &__label{
-      padding: 10px 0 10px 30px;
-      color: #888;
-      font-size: 12px;
-    }
-  
-    &__content{
-      word-wrap: break-word;
-    }
-  
-    p{
-      &:not(.tasks-show__label){
-        margin-bottom: 10px;
-        padding: 0 30px 10px 30px;
-      }
-    }
-  }
 }
-
 .pagination{
   width: fit-content;
   margin-left: auto;
@@ -254,58 +339,50 @@
   }
 }
 
-// form
+// input_ボタン
+.button{
+  &-blue{
+    padding: 20px 40px;
+    background-color: $base-color !important;
+    color: $base-color-white;
+    font-size: 40px;
+    font-weight: bold;
+    border-radius: 50px;
+  }
 
+  &-white{
+    padding: 20px 40px;
+    background-color: $base-color-white;
+    color: $base-color;
+    font-size: 40px;
+    font-weight: bold;
+    border-radius: 50px;
+  }
+}
+
+#overlay{
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.6);
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1;
+}
+
+// エラーメッセージ
 .error-message{
-  font-size: 15px;
-  color: red;
-  margin: 10px 0;
+  font-size: 27px;
+  color: $admin-color;
 }
 
-.form-list{
-  width: 727px;
-  margin: 0 30px;
-  font-size: 15px;
-  display: flex;
-  flex-direction: column;
-
-  input, textarea, select{
-    width: 400px;
-    height: 30px;
-    margin-top: 5px;
-    border: solid 1px #ddd;
-    border-radius: 5px;
-
-    &:is(.button){
-      margin-top: 15px;
-      border: none;
-      width: fit-content;
-      height: fit-content;
-    }
-
-    &:is(.form-list__content){
-      height: 100px;
-    }
-  }
-
-  label{
-    margin: 15px 0 5px 0;
-    color: #888;
-    font-size: 12px;
-  }
-}
-
+// フォームのエラー時の表示
 .field_with_errors{
   input, textarea, select{
-    margin-top: 5px;
-    border: solid 1px #ddd;
-    border-radius: 5px;
-  }
-
-  label{
-    color: red;
-    font-size: 12px;
-    font-weight: bold;
-    padding: 15px 0 5px 0;
+    color: $admin-color;
+    &::placeholder {
+      padding: 0;
+      color: $admin-color;
+    }
   }
 }

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -336,3 +336,7 @@
     }
   }
 }
+
+#tasks-form-button{
+  display: none;
+}

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -28,10 +28,9 @@ class TasksController < ApplicationController
 
   def update
     if @task.update(task_params)
-      redirect_to tasks_path, notice: t('notice.update')
+      redirect_to tasks_path
     else
-      flash.now[:alert] = t('alert.update')
-      render :edit
+      render :show
     end
   end
   

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,6 @@
 
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <script src="https://kit.fontawesome.com/5f5b2a7314.js" crossorigin="anonymous"></script>
-    <%= javascript_include_tag 'application' %>
   </head>
 
   <body class='tasks-body'>
@@ -16,4 +15,5 @@
       <%= yield %>
     </main>
   </body>
+  <%= javascript_include_tag 'application' %>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,16 +11,6 @@
   </head>
 
   <body class='tasks-body'>
-    <% if flash[:notice] %>
-      <div class='task_flash'>
-        <%= flash[:notice] %>
-      </div>
-    <% end %>
-    <% if flash[:alert] %>
-      <div class='task_flash'>
-        <%= flash[:alert] %>
-      </div>
-    <% end %>
     <%= render 'header'%>
     <main class='tasks-card'>
       <%= yield %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,21 +1,114 @@
-<%= render 'task_template' %>
-  <main class='tasks-show'>
-    <ul class="error_message_list">
-      <% if @task %>
-        <% @task.errors.full_messages.each do |message| %>
-          <li class="error_message"><%= message %></li>
+<div class='tasks-card__header'>
+  <%= link_to tasks_path do %>
+  <div class='tasks-back'>
+    <i class='fas fa-angle-left tasks-back__icon'></i>
+    <p>一覧</p>
+  </div>
+  <% end %>
+  <p class='tasks__label-title'>タスク詳細</p>
+</div>
+<%# タスク詳細 start %>
+<%= form_with model: @task, class: 'task-show__form', local: true do |form| %>
+  <ul class='tasks-show'>
+    <%# タスクのタイトル %>
+    <li>
+      <div>
+        <i class='far fa-check-circle tasks-show__icon--title'></i>
+      </div>
+      <div>
+        <%= form.text_field :title, class:'tasks-show__title', placeholder: 'タイトルを記入', id: 'task_title' %>
+        <% if @task.errors.include?(:title) %>
+          <p class='error-message'><%= @task.errors.full_messages_for(:title).first %></p>
         <% end %>
-      <% end %>
-    </ul>
-    <h2 class='tasks-show__title mb-15'><%= @task.title%></h2>
-    <p class='tasks-show__label'>内容</p>
-    <p class='tasks-show__content'><%= @task.content%></p>
-    <p class='tasks-show__label'>終了期限</p>
-    <p class='tasks-show_deadline'><%= l @task.deadline, format: :short %></p>
-    <p class='tasks-show__label'>ステータス</p>
-    <p class='tasks-show__status'><%= I18n.t("enums.task.status.#{@task.status}") %></p>
-    <p class='tasks-show__label'>優先順位</p>
-    <p class='tasks-show__priority'><%= I18n.t("enums.task.priority.#{@task.priority}") %></p>
-    <%= link_to "編集", edit_task_path(params[:id]), class: 'button ml-30' %>
-    <%= link_to "削除", task_path(@task.id), { method: "delete", class: 'button ml-30' } %>
-  </main>
+      </div>
+    </li>
+    <%# タスクの期限 %>
+    <li>
+      <div>
+        <i class='far fa-calendar tasks-show__icon--deadline'></i>
+      </div>
+      <div>
+         <%= form.date_field :deadline, {} %>
+      </div>
+    </li>
+    <%# タスクの内容 %>
+    <li>
+      <div>
+        <i class='far fa-comment-alt tasks-show__icon--content'></i>
+      </div>
+      <div>
+        <%= form.text_area :content, class:'tasks-show__content', id: 'task_content', placeholder: '内容を記入' %>
+        <% if @task.errors.include?(:content) %>
+          <p class='error-message'><%= @task.errors.full_messages_for(:content).first %></p>
+        <% end %>
+      </div>
+    </li>
+    <%# タスクのステータス %>
+    <li>
+      <div>
+        <i class='fas fa-tasks tasks-show__icon--status'></i>
+      </div>
+      <div class='tasks-select'>
+        <%= form.select :status, show_japanese_choices(Task.statuses, 'status') %>
+        <div class='tasks-select__bar'><div>
+      </div>
+    </li>
+    <%# タスクの優先順位 %>
+    <li>
+      <div>
+        <i class='fas fa-exclamation-triangle tasks-show__icon--priority'></i>
+      </div>
+      <div class='tasks-select'>
+        <%= form.select :priority, show_japanese_choices(Task.priorities, 'priority') %>
+        <div class='tasks-select__bar'><div>
+      </div>
+    </li>
+    <li>
+      <%= form.submit '完了' ,class:'button-blue',id: 'tasks-form-button' %>
+    </li>
+    <%# タスクの削除 %>
+    <%= link_to task_path(@task.id), method: "delete" do %>
+      <li class='tasks-show__destroy'>
+        <div>
+          <i class='far fa-trash-alt tasks-show__icon--destroy'></i>
+        </div>
+        <div>
+          <p>タスクを削除する</p>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+<%# タスク詳細 end %>
+
+<script>
+  // 完了ボタンを非表示
+  document.getElementById('tasks-form-button').style.display = "none";
+
+  // 完了ボタンを表示 start
+  // タイトルが変更されると完了ボタンが表示
+  document.getElementById("task_title").onchange = function() {
+    document.getElementById('tasks-form-button').style.display = "";
+  }
+
+  // 内容が変更されると完了ボタンが表示
+  document.getElementById("task_content").onchange = function() {
+    document.getElementById('tasks-form-button').style.display = "";
+  }
+
+  // 期限が変更されると完了ボタンが表示
+  document.getElementById("task_deadline").onchange = function() {
+    document.getElementById('tasks-form-button').style.display = "";
+  }
+
+  // 優先順位が変更されると完了ボタンが表示
+  document.getElementById("task_priority").onchange = function() {
+    document.getElementById('tasks-form-button').style.display = "";
+  }
+
+  // ステータスが変更されると完了ボタンが表示
+  document.getElementById("task_status").onchange = function() {
+    document.getElementById('tasks-form-button').style.display = "";
+  }
+  // 完了ボタンを表示 end
+</script>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -80,5 +80,3 @@
   </ul>
 <% end %>
 <%# タスク詳細 end %>
-
-<%= javascript_include_tag 'tasks' %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -81,34 +81,4 @@
 <% end %>
 <%# タスク詳細 end %>
 
-<script>
-  // 完了ボタンを非表示
-  document.getElementById('tasks-form-button').style.display = "none";
-
-  // 完了ボタンを表示 start
-  // タイトルが変更されると完了ボタンが表示
-  document.getElementById("task_title").onchange = function() {
-    document.getElementById('tasks-form-button').style.display = "";
-  }
-
-  // 内容が変更されると完了ボタンが表示
-  document.getElementById("task_content").onchange = function() {
-    document.getElementById('tasks-form-button').style.display = "";
-  }
-
-  // 期限が変更されると完了ボタンが表示
-  document.getElementById("task_deadline").onchange = function() {
-    document.getElementById('tasks-form-button').style.display = "";
-  }
-
-  // 優先順位が変更されると完了ボタンが表示
-  document.getElementById("task_priority").onchange = function() {
-    document.getElementById('tasks-form-button').style.display = "";
-  }
-
-  // ステータスが変更されると完了ボタンが表示
-  document.getElementById("task_status").onchange = function() {
-    document.getElementById('tasks-form-button').style.display = "";
-  }
-  // 完了ボタンを表示 end
-</script>
+<%= javascript_include_tag 'tasks' %>


### PR DESCRIPTION
## 概要
タスク画面のデザイン修正

## 要件・仕様
フェーズ3.5
タスク画面のデザイン修正
https://docs.google.com/spreadsheets/d/10mpuQGl6XKAXZpB_TOI31MXAfQakQYupD9k-pmlIix8/edit#gid=0

## 動作確認
- 通常画面
<img width="323" alt="スクリーンショット 2021-04-12 13 07 25" src="https://user-images.githubusercontent.com/78336288/114341313-6eb8c500-9b94-11eb-916c-5e7527d9735d.png">

- 変更がある時
<img width="324" alt="スクリーンショット 2021-04-12 13 07 43" src="https://user-images.githubusercontent.com/78336288/114341317-70828880-9b94-11eb-9b1c-abaca7f458c8.png">

- エラー時
<img width="322" alt="スクリーンショット 2021-04-12 13 08 06" src="https://user-images.githubusercontent.com/78336288/114341320-71b3b580-9b94-11eb-8663-6b00c99b25b2.png">


## ラフ
![タスク画面@2x](https://user-images.githubusercontent.com/78336288/114341292-61033f80-9b94-11eb-9b01-2726ab0f12fa.png)
